### PR TITLE
Fix logo visibility in dark mode and remove confidence

### DIFF
--- a/client/components/RecommendationNotifications.tsx
+++ b/client/components/RecommendationNotifications.tsx
@@ -87,7 +87,7 @@ export function RecommendationNotifications() {
           id: aiRec.id,
           type: "ai-recommendation",
           title: `AI: ${aiRec.action}`,
-          description: `${aiRec.reason} (Confidence: ${Math.round(aiRec.confidence * 100)}%)`,
+          description: aiRec.reason,
           priority: aiRec.priority,
           dueDate: now,
           relatedEntity: {

--- a/client/components/UserHeader.tsx
+++ b/client/components/UserHeader.tsx
@@ -86,11 +86,13 @@ export function UserHeader({
       <div className="px-6 py-3 flex items-center justify-between">
         {/* Left side - Logo and Title */}
         <div className="flex items-center space-x-4">
-          <img
-            src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2Fe158bed7731d41aa84ba65ca872152aa?format=webp&width=800"
-            alt="Yitro"
-            className="h-8 w-auto"
-          />
+          <div className="p-2 bg-white dark:bg-white rounded-md">
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2Fe158bed7731d41aa84ba65ca872152aa?format=webp&width=800"
+              alt="Yitro"
+              className="h-8 w-auto"
+            />
+          </div>
           <div className="flex items-center space-x-2">
             <User className="h-5 w-5 text-blue-600" />
             <span className="text-lg font-semibold text-gray-900 dark:text-gray-100">

--- a/client/pages/ProductionLogin.tsx
+++ b/client/pages/ProductionLogin.tsx
@@ -150,11 +150,13 @@ export default function ProductionLogin() {
       <div className="min-h-screen bg-login-gradient flex items-center justify-center p-4">
         <div className="w-full max-w-md space-y-8">
           <div className="text-center">
-            <img
-              src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
-              alt="Yitro Logo"
-              className="mx-auto h-16 w-auto mb-8"
-            />
+            <div className="inline-block p-4 bg-white dark:bg-white rounded-lg mb-8">
+              <img
+                src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
+                alt="Yitro Logo"
+                className="h-16 w-auto"
+              />
+            </div>
           </div>
 
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 text-center">

--- a/client/pages/ProductionLogin.tsx
+++ b/client/pages/ProductionLogin.tsx
@@ -194,11 +194,13 @@ export default function ProductionLogin() {
       <div className="w-full max-w-md space-y-8">
         {/* Logo */}
         <div className="text-center">
-          <img
-            src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
-            alt="Yitro Logo"
-            className="mx-auto h-16 w-auto mb-8"
-          />
+          <div className="inline-block p-4 bg-white dark:bg-white rounded-lg mb-8">
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
+              alt="Yitro Logo"
+              className="h-16 w-auto"
+            />
+          </div>
           <div className="inline-flex items-center justify-center w-24 h-24 border-2 border-white/30 rounded-full bg-white/10 backdrop-blur-sm">
             <User className="w-12 h-12 text-white" strokeWidth={1.5} />
           </div>

--- a/client/pages/ResetPassword.tsx
+++ b/client/pages/ResetPassword.tsx
@@ -164,11 +164,13 @@ export default function ResetPassword() {
       <div className="w-full max-w-md space-y-8">
         {/* Logo */}
         <div className="text-center">
-          <img
-            src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
-            alt="Yitro Logo"
-            className="mx-auto h-16 w-auto mb-8"
-          />
+          <div className="inline-block p-4 bg-white dark:bg-white rounded-lg mb-8">
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
+              alt="Yitro Logo"
+              className="h-16 w-auto"
+            />
+          </div>
           <div className="inline-flex items-center justify-center w-24 h-24 border-2 border-white/30 rounded-full bg-white/10 backdrop-blur-sm">
             <Lock className="w-12 h-12 text-white" strokeWidth={1.5} />
           </div>

--- a/client/pages/ResetPassword.tsx
+++ b/client/pages/ResetPassword.tsx
@@ -132,11 +132,13 @@ export default function ResetPassword() {
       <div className="min-h-screen bg-login-gradient flex items-center justify-center p-4">
         <div className="w-full max-w-md space-y-8">
           <div className="text-center">
-            <img
-              src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
-              alt="Yitro Logo"
-              className="mx-auto h-16 w-auto mb-8"
-            />
+            <div className="inline-block p-4 bg-white dark:bg-white rounded-lg mb-8">
+              <img
+                src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
+                alt="Yitro Logo"
+                className="h-16 w-auto"
+              />
+            </div>
           </div>
 
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 text-center">

--- a/client/pages/ResetPassword.tsx
+++ b/client/pages/ResetPassword.tsx
@@ -97,11 +97,13 @@ export default function ResetPassword() {
       <div className="min-h-screen bg-login-gradient flex items-center justify-center p-4">
         <div className="w-full max-w-md space-y-8">
           <div className="text-center">
-            <img
-              src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
-              alt="Yitro Logo"
-              className="mx-auto h-16 w-auto mb-8"
-            />
+            <div className="inline-block p-4 bg-white dark:bg-white rounded-lg mb-8">
+              <img
+                src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
+                alt="Yitro Logo"
+                className="h-16 w-auto"
+              />
+            </div>
           </div>
 
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 text-center">

--- a/client/pages/VerifyEmail.tsx
+++ b/client/pages/VerifyEmail.tsx
@@ -52,11 +52,13 @@ export default function VerifyEmail() {
       <div className="w-full max-w-md space-y-8">
         {/* Logo */}
         <div className="text-center">
-          <img
-            src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
-            alt="Yitro Logo"
-            className="mx-auto h-16 w-auto mb-8"
-          />
+          <div className="inline-block p-4 bg-white dark:bg-white rounded-lg mb-8">
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F087df647f1e8465b80d17ed1202a1a86%2F874635e44e4546cc93b707faf6deafea?format=webp&width=800"
+              alt="Yitro Logo"
+              className="h-16 w-auto"
+            />
+          </div>
         </div>
 
         {/* Verification Status */}


### PR DESCRIPTION
## Purpose
Users reported that the Yitro logo was not visible in dark mode across user pages and requested it to have a white background similar to the admin page. Additionally, users wanted to remove the confidence percentage display from AI recommendation notifications to simplify the interface.

## Code changes
- **Logo visibility**: Added white background containers (`bg-white dark:bg-white rounded-lg/md`) around Yitro logos in:
  - UserHeader component
  - ProductionLogin page
  - ResetPassword page  
  - VerifyEmail page
- **Notifications**: Removed confidence percentage display from AI recommendation descriptions in RecommendationNotifications component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/554ff0e8d6864e3c8b71b1693c281542/nova-hub)

👀 [Preview Link](https://554ff0e8d6864e3c8b71b1693c281542-nova-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>554ff0e8d6864e3c8b71b1693c281542</projectId>-->
<!--<branchName>nova-hub</branchName>-->